### PR TITLE
feat: Make SSH key mounting optional and improve container resilience

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -34,6 +34,7 @@ To set up the development environment:
 -   **Verification**: After making any code changes, always run relevant tests to ensure functionality.
 -   **Code Quality**: Before finalizing changes, check for any linting or formatting errors.
 -   **Ambiguity**: If instructions are unclear or conflicting, ask for clarification from the user before proceeding.
+-   **Documentation**: Keep this `AGENTS.md` file updated with any new instructions or changes in workflow.
 
 ## Version Control
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,8 +89,8 @@ services:
         volumes:
             - code_m2:/home/dev/.m2
             - code_vol:/code
-            - ~/.ssh/id_ed25519:/home/dev/host/ssh_key_private:ro
-            - ~/.ssh/id_ed25519.pub:/home/dev/host/ssh_key_public:ro
+            # - ~/.ssh/id_ed25519:/home/dev/host/ssh_key_private:ro
+            # - ~/.ssh/id_ed25519.pub:/home/dev/host/ssh_key_public:ro
         networks:
             - db-net
             - ingress-net

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,13 +104,12 @@ start_sshd() {
         echo "Public key should be at ${PUBLIC_KEY_SRC}"
         echo "Private key should be at ${PRIVATE_KEY_SRC}"
 
-        if [[ -n "${DEBUG}" ]]; then
-            debug_log "DEBUG mode enabled. Keeping container running with 'tail -f /dev/null'."
-            exec tail -f /dev/null
-        else
-            error "Exiting container due to SSH configuration failure."
-            exit 1
-        fi
+        log "SSH not fully configured. Keeping container running and logging time every 10 minutes."
+        # Log the current time every 10 minutes as the main process
+        while true; do
+            log "Container alive at: $(date)"
+            sleep 600 # Sleep for 10 minutes (600 seconds)
+        done
     fi
 }
 


### PR DESCRIPTION
This PR makes SSH key mounting optional by commenting out the volume mounts in . It also improves container resilience by modifying  to keep the container running and log the current time every 10 minutes if SSH keys are not found.